### PR TITLE
Deregister 'offending' table metrics when table is DROPped

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1034,6 +1034,8 @@ bool database::update_column_family(schema_ptr new_schema) {
 void database::remove(const table& cf) noexcept {
     auto s = cf.schema();
     auto& ks = find_keyspace(s->ks_name());
+    table& mutable_cf = const_cast<table&>(cf);
+    mutable_cf.deregister_metrics();
     _column_families.erase(s->id());
     ks.metadata()->remove_column_family(s);
     _ks_cf_to_uuid.erase(std::make_pair(s->ks_name(), s->cf_name()));

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -396,13 +396,16 @@ public:
         cache_temperature rate;
         lowres_clock::time_point last_updated;
     };
+
+    void deregister_metrics();
+
 private:
     schema_ptr _schema;
     config _config;
     locator::effective_replication_map_ptr _erm;
     lw_shared_ptr<const storage_options> _storage_opts;
     mutable table_stats _stats;
-    mutable db::view::stats _view_stats;
+    mutable std::unique_ptr<db::view::stats> _view_stats;
     mutable row_locker::stats _row_locker_stats;
 
     uint64_t _failed_counter_applies_to_memtable = 0;
@@ -454,7 +457,7 @@ private:
     db::rate_limiter::label _rate_limiter_label_for_reads;
 
     void set_metrics();
-    seastar::metrics::metric_groups _metrics;
+    std::unique_ptr<seastar::metrics::metric_groups> _metrics = std::make_unique<seastar::metrics::metric_groups>();
 
     // holds average cache hit rate of all shards
     // recalculated periodically
@@ -932,7 +935,7 @@ public:
     }
 
     const db::view::stats& get_view_stats() const {
-        return _view_stats;
+        return *_view_stats;
     }
 
     replica::cf_stats* cf_stats() {


### PR DESCRIPTION
The metrics that are being deregistered (in this PR) cause Scylla to crash when a table is dropped, but the corresponding table object in memory is not yet deallocated, and a new table with the same name is created. This causes double-metrics-registration exception to be thrown. In order to avoid it, we are deregistering table's metrics as soon as the table is getting removed from the database. It's representation in memory can still live, but shouldn't forbid other table with the same name to be created.