### PR TITLE
test: Fix the way tablets RF-change test parses mutation_fragments

### DIFF
--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -110,6 +110,8 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
     cfg = {'enable_user_defined_functions': False,
            'experimental_features': ['tablets']}
     servers = await manager.servers_add(3, config=cfg)
+    for s in servers:
+        await manager.api.disable_tablet_balancing(s.ip_addr)
 
     cql = manager.get_cql()
     res = await cql.run_async("SELECT data_center FROM system.local")
@@ -146,7 +148,7 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
     logger.info(f"Checking {rf_to} re-allocated replicas")
     await check_allocated_replica(rf_to)
 
-    fragments = { pk: [] for pk in random.sample(range(128), 17) }
+    fragments = { pk: set() for pk in random.sample(range(128), 17) }
     for s in servers:
         host_id = await manager.get_host_id(s.server_id)
         host = await wait_for_cql_and_get_hosts(cql, [s], time.time() + 30)
@@ -155,7 +157,7 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
             res = await cql.run_async(f"SELECT partition_region FROM MUTATION_FRAGMENTS(test.test) WHERE pk={k}", host=host[0])
             for fragment in res:
                 if fragment.partition_region == 0: # partition start
-                    fragments[k].append(host_id)
+                    fragments[k].add(host_id)
     logger.info("Checking fragments")
     for k in fragments:
         assert len(fragments[k]) == rf_to, f"Found mutations for {k} key on {fragments[k]} hosts, but expected only {rf_to} of them"


### PR DESCRIPTION
When the test changes RF from 2 to 3, the extra node executes "rebuild" transition which means that it streams tablets replicas from two other peers. When doing it, the node receives two sets of sstables with mutations from the given tablet. The test part that checks if the extra node received the mutations notices two mutation fragments on the new replica and errorneously fails by seeing, that RF=3 is not equal to the number of mutations found, which is 4.